### PR TITLE
Manually delete singletons before deleting the class_loaders

### DIFF
--- a/src/PluginLoader.cpp
+++ b/src/PluginLoader.cpp
@@ -13,6 +13,7 @@ PluginLoader::PluginLoader(bool auto_load_xml_files) : PluginManager(std::vector
 
 PluginLoader::~PluginLoader()
 {
+    singletons.clear();
     loaders.clear();
 }
 


### PR DESCRIPTION
This PR should fix #1 

In `~PluginLoader()` the `loaders` map was manually cleared. This destroyed all class_loader instances.
Afterwards, during the destruction of  `singletons` some callbacks to the class_loader instances where triggered. However the corresponding loaders no longer existed causing this crash.